### PR TITLE
Fix the issue of missing dependencies of `cbuild` command when run the shell run_demo.sh

### DIFF
--- a/object_classification/run_demo.sh
+++ b/object_classification/run_demo.sh
@@ -142,7 +142,7 @@ cpackget add -f packs.txt
 
 PROJECT_FILE_NAME="object_classification+PaddleClas$RUN_DEVICE_NAME.cprj"
 echo "Project file name is $PROJECT_FILE_NAME"
-cbuild "$PROJECT_FILE_NAME"
+cbuild -p "$PROJECT_FILE_NAME"
 
 rm -rf "${PWD}/cls"
 rm "${PWD}/include/inputs.h"

--- a/object_detection/run_demo.sh
+++ b/object_detection/run_demo.sh
@@ -119,7 +119,7 @@ rm det.tar
 
  PROJECT_FILE_NAME="object_detection+$MODEL_NAME$RUN_DEVICE_NAME.cprj"
  echo "Project file name is $PROJECT_FILE_NAME"
- cbuild "$PROJECT_FILE_NAME"
+ cbuild -p "$PROJECT_FILE_NAME"
 
  rm -rf "${PWD}/cls"
  rm "${PWD}/include/inputs.h"

--- a/object_segmentation/run_demo.sh
+++ b/object_segmentation/run_demo.sh
@@ -125,7 +125,7 @@ cpackget update-index
 cpackget add -f packs.txt
 PROJECT_FILE_NAME="object_segmentation+$MODEL_NAME$RUN_DEVICE_NAME.cprj"
 echo "Project file name is $PROJECT_FILE_NAME"
-cbuild "$PROJECT_FILE_NAME"
+cbuild -p "$PROJECT_FILE_NAME"
 
 rm -rf "${PWD}/object_segmentation"
 rm "${PWD}/include/inputs.h"

--- a/ocr/text_angle_classification/run_demo.sh
+++ b/ocr/text_angle_classification/run_demo.sh
@@ -119,7 +119,7 @@ cpackget update-index
 cpackget add -f packs.txt
 PROJECT_FILE_NAME="text_angle_classification+$MODEL_NAME$RUN_DEVICE_NAME.cprj"
 echo "Project file name is $PROJECT_FILE_NAME"
-cbuild "$PROJECT_FILE_NAME"
+cbuild -p "$PROJECT_FILE_NAME"
 
 rm -rf "${PWD}/text_angle_cls"
 rm "${PWD}/include/inputs.h"

--- a/ocr/text_recognition/run_demo.sh
+++ b/ocr/text_recognition/run_demo.sh
@@ -125,7 +125,7 @@ cpackget update-index
 cpackget add -f packs.txt
 PROJECT_FILE_NAME="text_recognition+$MODEL_NAME$RUN_DEVICE_NAME.cprj"
 echo "Project file name is $PROJECT_FILE_NAME"
-cbuild "$PROJECT_FILE_NAME"
+cbuild -p "$PROJECT_FILE_NAME"
 
 rm -rf "${PWD}/text_recognition"
 rm "${PWD}/include/inputs.h"


### PR DESCRIPTION
### Pull Request Type：Enhancement

### Description

Fix the issue of missing dependencies of `cbuild` command when run the shell run_demo.sh

### Related Issue
None

### Implementation Details
When first running the shell run_demo.sh in the AVH BCC, it will occurred a missing dependencies error for `cbuild` command,
after add the parameter: `-p` with  `cbuild`, it will automate download missing software packs with `cpackget`.

### Screenshots
![image](https://github.com/ArmDeveloperEcosystem/Paddle-examples-for-AVH/assets/25427352/0aacaa66-8a36-4700-88a4-911870a75cbf)



