### PR TITLE
change the cmsis-toolbox-linux pack from amd to arm

### DIFF
--- a/scripts/config_cmsis_toolbox.sh
+++ b/scripts/config_cmsis_toolbox.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # download cmsis-toolbox
-cmsis_toolbox_name="cmsis-toolbox-linux-amd64"
+cmsis_toolbox_name="cmsis-toolbox-linux-arm64"
 cmsis_toolbox_version="2.2.1"
 cmsis_toolbox_url="https://github.com/Open-CMSIS-Pack/cmsis-toolbox/releases/download/${cmsis_toolbox_version}/${cmsis_toolbox_name}.tar.gz"
 wget ${cmsis_toolbox_url}


### PR DESCRIPTION
我在运行此示例的时候（使用百度智能云的arm虚拟硬件实例）遇到的问题是此脚本中的 arm 工具包无法使用（当然，因为我在虚拟 arm 平台上运行 amd 文件肯定出错）。修改为 arm64 包后可以正常运行。我不知道此项目是否是针对百度智能云的 arm 虚拟硬件平台而创立的项目，如果是的话那也许我们应该把工具包修改为正确的架构？
如果我对此项目功能理解有误，您忽略此 pr 就好。